### PR TITLE
Correct Heroku initialization command

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Next, `cd` in to deploy the code. Then, setup the Heroku server by typing the
 following two commands.
 
 ```bash
-$ heroku init
+$ heroku create
 $ git push heroku master
 ```
 


### PR DESCRIPTION
`heroku init` is not an actual command, whereas `heroku create` is the appropriate one. Accidentally, overlooked this when initially creating the write-up.