### PR TITLE
fix 'what song is this?' for playlists

### DIFF
--- a/geemusic/utils/music_queue.py
+++ b/geemusic/utils/music_queue.py
@@ -43,12 +43,15 @@ class MusicQueue:
         self.song_ids = []
 
         for track in tracks:
+            # when coming from a playlist, track info is nested
+            # under the "track" key
+            if 'track' in track:
+                track = track['track']
+
             if 'storeId' in track:
                 song_id = track['storeId']
             elif 'trackId' in track:
                 song_id = track['trackId']
-            elif 'track' in track:
-                song_id = track['track']['storeId']
             else:
                 continue
 


### PR DESCRIPTION
So I don't know if this is right, but it gets "what song is this?" when playing a playlist working for me. Basically. "what song is this" was looking for track['title'], but for a playlist it needed track['track']['title'].

And while we're at it, under what scenario is the song id 'storeId' instead of 'trackId'?