### PR TITLE
Last.fm Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ $ heroku config:set GOOGLE_PASSWORD=[password]
 $ heroku config:set APP_URL=https://[heroku_app_name].herokuapp.com
 ```
 
-At this point, your server should by live and ready to start accepting requests at `https://[heroku_app_name].herokuapp.com/alexa.`
+At this point, your server should by live and ready to start accepting requests at
+`https://[heroku_app_name].herokuapp.com/alexa.` Note, that while using the free tier,
+you may experience timeout errors when you server has received no requests for over
+30 minutes.
 
 ## Contributing
 Please feel free to open an issue or PR if you've found a bug. If you're

--- a/README.md
+++ b/README.md
@@ -229,9 +229,7 @@ Flask Ask used to have a bug that would not resume the song from the correct off
 ### Music won't start playing
 Issues where Alexa responds to your requests but doesn't play music are
 generally caused by the `APP_URL` environment variable being set improperly. Be
-sure that it is set to something like `APP_URL=https://ff9b5cce.ngrok.io` 
-
-*without a trailing slash or `/alexa`**.
+sure that it is set to something like `APP_URL=https://ff9b5cce.ngrok.io` **without a trailing slash or `/alexa`**.
 
 ## Contributing
 Please feel free to open an issue or PR if you've found a bug. If you're

--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -8,6 +8,7 @@ def redirect_to_stream(song_id):
     stream_url = api.get_google_stream_url(song_id)
     # Scrobble if Last.fm is setup
     if environ['LAST_FM_ACTIVE']:
+        from utils import last_fm
         last_fm.execute(song_id)
 
     app.logger.debug('URL is %s' % stream_url)

--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -11,8 +11,8 @@ def redirect_to_stream(song_id):
         from utils import last_fm
         song_info = api.get_song_data(song_id)
         last_fm.scrobble(
-            song_info.title,
-            song_info.artist,
+            song_info['title'],
+            song_info['artist'],
             environ['LAST_FM_SESSION_KEY']
         )
 

--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -9,7 +9,12 @@ def redirect_to_stream(song_id):
     # Scrobble if Last.fm is setup
     if environ['LAST_FM_ACTIVE']:
         from utils import last_fm
-        last_fm.execute(song_id)
+        song_info = api.get_song_data(song_id)
+        last_fm.scrobble(
+            song_info.title,
+            song_info.artist,
+            environ['LAST_FM_SESSION_KEY']
+        )
 
     app.logger.debug('URL is %s' % stream_url)
 

--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -7,7 +7,7 @@ from geemusic.utils.music import GMusicWrapper
 def redirect_to_stream(song_id):
     stream_url = api.get_google_stream_url(song_id)
     # Scrobble if Last.fm is setup
-    if environ['LAST_FM_ACTIVE']:
+    if environ.get('LAST_FM_ACTIVE'):
         from utils import last_fm
         song_info = api.get_song_data(song_id)
         last_fm.scrobble(

--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -6,6 +6,9 @@ from geemusic.utils.music import GMusicWrapper
 @app.route("/stream/<song_id>")
 def redirect_to_stream(song_id):
     stream_url = api.get_google_stream_url(song_id)
+    # Scrobble if Last.fm is setup
+    if environ['LAST_FM_ACTIVE']:
+        last_fm.execute(song_id)
 
     app.logger.debug('URL is %s' % stream_url)
 

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -1,0 +1,11 @@
+# Last.fm Syncing Tool
+import os
+import requests
+
+def authorize():
+    # TODO: Create function
+    doNothing = True
+
+def scrobble(song_name, artist_name):
+    apiResp = requests.post('http://ws.audioscrobbler.com/2.0/', {'method': 'track.updateNowPlaying', 'apiKey': os.environ['LAST_FM_API'], 'track': song_name, 'artist': artist_name})
+    print apiResp.text

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -69,4 +69,5 @@ def get_google_song(song_id):
 def execute(song_id):
     print "Finding: ", song_id
     track = get_google_song(song_id)
+    print "Found: ", track.title, track.artist
     scrobble(track.title, track.artist, os.environ['LAST_FM_SESSION_KEY'])

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -40,7 +40,7 @@ def scrobble(song_name, artist_name, session_key):
     params = {
             'method': 'track.scrobble',
             'api_key': os.environ['LAST_FM_API'],
-            'timestamp': str( int( time.time() ),
+            'timestamp': str( int( time.time() ) ),
             'track': song_name,
             'artist': artist_name,
             'sk': session_key

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -63,7 +63,8 @@ def hashRequest(obj, secretKey):
     return requestHash
 
 def get_google_song(song_id):
-    info = Mobileclient.get_track_info(song_id)
+    gApi = MobileClient()
+    info = gApi.get_track_info(song_id)
     return info
 
 def execute(song_id):

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -1,11 +1,72 @@
 # Last.fm Syncing Tool
+# Lean, fast, and functional
 import os
+import time
+import datetime
 import requests
+import md5
 
-def authorize():
-    # TODO: Create function
-    doNothing = True
+from gmusicapi import CallFailure, Mobileclient
 
-def scrobble(song_name, artist_name):
-    apiResp = requests.post('http://ws.audioscrobbler.com/2.0/', {'method': 'track.updateNowPlaying', 'apiKey': os.environ['LAST_FM_API'], 'track': song_name, 'artist': artist_name})
-    print apiResp.text
+api_head = 'http://ws.audioscrobbler.com/2.0/'
+secret = os.environ['LAST_FM_API_SECRET']
+
+def authorize(user_token):
+    params = {
+            'api_key': os.environ['LAST_FM_API'],
+            'method': 'auth.getSession',
+            'token': user_token
+            }
+    requestHash = hashRequest(params, secret)
+    params['api_sig'] = requestHash
+    apiResp = requests.post(api_head, params)
+    return apiResp.text
+
+def nowPlaying(song_name, artist_name, session_key):
+    params = {
+            'method': 'track.updateNowPlaying',
+            'api_key': os.environ['LAST_FM_API'],
+            'track': song_name,
+            'artist': artist_name,
+            'sk': session_key
+            }
+    requestHash = hashRequest(params, secret)
+    params['api_sig'] = requestHash
+    apiResp = requests.post(api_head, params)
+    return apiResp.text
+
+def scrobble(song_name, artist_name, session_key):
+    # Currently this sort of cheats the timestamp protocol
+    params = {
+            'method': 'track.scrobble',
+            'api_key': os.environ['LAST_FM_API'],
+            'timestamp': str( int( time.time() ),
+            'track': song_name,
+            'artist': artist_name,
+            'sk': session_key
+            }
+    requestHash = hashRequest(params, secret)
+    params['api_sig'] = requestHash
+    apiResp = requests.post(api_head, params)
+    return apiResp.text
+
+def hashRequest(obj, secretKey):
+    string = ''
+    items = obj.keys()
+    items.sort()
+    for i in items:
+        string += i
+        string += obj[i]
+    string += secretKey
+    stringToHash = string.encode('utf8')
+    requestHash = md5.new(stringToHash).hexdigest()
+    return requestHash
+
+def get_google_song(song_id):
+    info = Mobileclient.get_track_info(song_id)
+    return info
+
+def execute(song_id):
+    print "Finding: ", song_id
+    track = get_google_song(song_id)
+    scrobble(track.title, track.artist, os.environ['LAST_FM_SESSION_KEY'])

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -63,7 +63,7 @@ def hashRequest(obj, secretKey):
     return requestHash
 
 def get_google_song(song_id):
-    gApi = MobileClient()
+    gApi = Mobileclient()
     info = gApi.get_track_info(song_id)
     return info
 

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -61,14 +61,3 @@ def hashRequest(obj, secretKey):
     stringToHash = string.encode('utf8')
     requestHash = md5.new(stringToHash).hexdigest()
     return requestHash
-
-def get_google_song(song_id):
-    gApi = Mobileclient()
-    info = gApi.get_track_info(song_id)
-    return info
-
-def execute(song_id):
-    print "Finding: ", song_id
-    track = get_google_song(song_id)
-    print "Found: ", track.title, track.artist
-    scrobble(track.title, track.artist, os.environ['LAST_FM_SESSION_KEY'])

--- a/geemusic/utils/music.py
+++ b/geemusic/utils/music.py
@@ -124,6 +124,9 @@ class GMusicWrapper:
     def increment_song_playcount(self, song_id, plays=1, playtime=None):
         return self._api.increment_song_playcount(song_id, plays, playtime)
 
+    def get_song_data(self, song_id):
+        return self._api.get_track_info(song_id)
+
     @classmethod
     def generate_api(cls, **kwargs):
         return cls(environ['GOOGLE_EMAIL'], environ['GOOGLE_PASSWORD'], **kwargs)


### PR DESCRIPTION
This PR provides full support for scrobbling to the [Last.fm](http://www.last.fm) service. It is disabled by default, but technical users can set it up by acquiring the necessary API and user keys and enabling it through an environment variable. It worked in all my tests, and the underlying API wrapper should function perfectly as it has been tested extensively in isolation.