### PR TITLE
Make the last.fm scrobbling functionality compatible with Python 3

### DIFF
--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -9,7 +9,7 @@ def redirect_to_stream(song_id):
     stream_url = api.get_google_stream_url(song_id)
     # Scrobble if Last.fm is setup
     if environ.get('LAST_FM_ACTIVE'):
-        from utils import last_fm
+        from .utils import last_fm
         song_info = api.get_song_data(song_id)
         last_fm.scrobble(
             song_info['title'],

--- a/geemusic/utils/last_fm.py
+++ b/geemusic/utils/last_fm.py
@@ -52,7 +52,7 @@ def scrobble(song_name, artist_name, session_key):
 
 def hashRequest(obj, secretKey):
     string = ''
-    items = obj.keys()
+    items = list(obj.keys())
     items.sort()
     for i in items:
         string += i


### PR DESCRIPTION
I hadn't updated the module since the move to Python 3, so the scrobbling system stopped working. These two edits should make it fully functional again.