### PR TITLE
Remaining Amazon default AudioPlayer intents

### DIFF
--- a/speech_assets/intentSchema.json
+++ b/speech_assets/intentSchema.json
@@ -7,6 +7,12 @@
             "intent": "AMAZON.ResumeIntent"
         },
         {
+            "intent": "AMAZON.NextIntent"
+        },
+        {
+            "intent": "AMAZON.PreviousIntent"
+        },        
+        {
             "intent": "GeeMusicPlayArtistIntent",
             "slots": [
                 {"name":"artist_name", "type":"AMAZON.MusicGroup"}


### PR DESCRIPTION
Amzon Alexa documentation indicates: "This skill uses the AudioPlayer directives. Therefore, you must include the following built-in intents in your schema: AMAZON.PauseIntent, AMAZON.ResumeIntent. Optionally additional built-in intents for playback control include: AMAZON.NextIntent, AMAZON.PreviousIntent, AMAZON.LoopOnIntent, AMAZON.LoopOffIntent, AMAZON.ShuffleOnIntent, AMAZON.ShuffleOffIntent."

This fills in the remaining ones