### PR TITLE
Fix app debug mode setting

### DIFF
--- a/geemusic/__init__.py
+++ b/geemusic/__init__.py
@@ -10,10 +10,12 @@ from .utils.music_queue import MusicQueue
 app = Flask(__name__)
 ask = Ask(app, '/alexa')
 
-if str(environ['DEBUG_MODE']) is True:
+if str(environ['DEBUG_MODE']) == 'True':
     log_level = logging.DEBUG
+    app.debug = True
 else:
     log_level = logging.INFO
+    app.debug = False
 
 logging.getLogger("flask_ask").setLevel(log_level)
 

--- a/server.py
+++ b/server.py
@@ -3,4 +3,4 @@ import os
 
 if __name__ == '__main__':
     port = int(os.environ.get("PORT", 4000))
-    app.run(host='0.0.0.0', port=port, debug=True)
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
Problems:
`str(environ['DEBUG_MODE']) is True` will always evaluate to `False`.
Also, because `debug` is set to `True` in `app.run`, 500 will print stack trace even if DEBUG_MODE=False, this is not good.

This code fixes that.
