### PR TITLE
Added new route to wake up heroku via newrelic

### DIFF
--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -3,6 +3,9 @@ import requests
 from os import environ
 from geemusic import app, api
 
+@app.route('/wake-up')
+def index():
+	return 'I am not sleeping!'
 
 @app.route("/alexa/stream/<song_id>")
 def redirect_to_stream(song_id):


### PR DESCRIPTION
Prevent heroku from sleeping by monitoring https://[heroku_app_name].herokuapp.com/wake-up link via newrelic.
[stackoverflow](https://stackoverflow.com/a/5482285/2549284)