### PR TITLE
Add Japanese utterances

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is still in its early phases and subject to a bit of change, howeve
 **This Skill was developed to only work on devices (Echo, Dot, Tap etc) using English(US) on a Amazon US account**
 This is due to the Skill using features from the [Developer Preview of the ASK Built-in Library](https://developer.amazon.com/blogs/post/Tx2EWC85F6H422/Introducing-the-ASK-Built-in-Library-Developer-Preview-Pre-Built-Models-for-Hund). Which frustratingly has only been made available to developers in the US (edit: six months later and there is still no access for UK/DE).
 
-There is a workaround for English(UK) users (Amazon UK account) if they setup the Skill slightly differently, instructions are included below.
+There is a workaround for English(UK) and Japanese users if they setup the Skill slightly differently, instructions are included below.
 
 This language issue only affects the Echo/Amazon side of things and not your Google Music account [#100](https://github.com/stevenleeg/geemusic/issues/100)
 
@@ -129,7 +129,7 @@ Going through the various sections
 | Field | Value |
 | ----- | ----- |
 | Skill Type | Custom Interaction Model |
-| Language | Select US English or UK English |
+| Language | Select US English, UK English or Japanese |
 | Name | Gee Music |
 | Invocation Name | gee music |
 | Audio Player | Yes |
@@ -144,7 +144,7 @@ See the note at the top about supported languages.
 
 On the "Interaction Model" step, paste in the contents of `speech_assets/intentSchema.json` to the intent schema field and the contents of `speech_assets/sampleUtterances.txt` to the sample utterances field.
 
-#### UK English users
+#### Other language users
 
 On the "Interaction Model" step, you need to create your Custom Slot Types before the intent schema and sample utterances.
 
@@ -161,7 +161,7 @@ Repeat the process for each of the slots.
 
 The sample data was scraped from the UK top 100 singles and album chart. For the MUSICPLAYLISTS there are some generic sample phrases. The sample data is fine to use, don't feel you need to fill these slots to match your own collection.
 
-After you have added the "Custom Slots" you need to copy and paste the contents of `/speech_assets/non_us_custom_slot_version/intentSchema.json` to the intent schema field and the contents of `speech_assets/sampleUtterances.txt` to the sample utterances field.
+After you have added the "Custom Slots" you need to copy and paste the contents of `/speech_assets/non_us_custom_slot_version/intentSchema.json` to the intent schema field and the contents of `speech_assets/sampleUtterances.txt` to the sample utterances field. For Japanese users, use `speech_assets/sampleUtterances.ja.txt` to the utterances field.
 
 
 ### Configuration

--- a/speech_assets/sampleUtterances.ja.txt
+++ b/speech_assets/sampleUtterances.ja.txt
@@ -1,0 +1,102 @@
+GeeMusicPlayArtistIntent {artist_name}の曲を再生して
+GeeMusicPlayArtistIntent {artist_name}の曲を再生
+GeeMusicPlayArtistIntent アーティストの {artist_name} を再生
+GeeMusicPlayArtistIntent {artist_name} の曲を再生
+GeeMusicPlayArtistIntent {artist_name} の有名な曲を再生
+GeeMusicPlayArtistIntent {artist_name} の音楽を再生
+GeeMusicPlayArtistIntent {artist_name} のアルバムを再生
+
+GeeMusicPlayAlbumIntent {album_name} のアルバムを再生
+GeeMusicPlayAlbumIntent {album_name} のアルバムの曲を再生
+GeeMusicPlayAlbumIntent アルバムの {album_name} を再生
+GeeMusicPlayAlbumIntent {artist_name} の アルバム {album_name} を再生
+GeeMusicPlayAlbumIntent {artist_name} の {album_name} のアルバムを再生
+GeeMusicPlayAlbumIntent {artist_name} の {album_name} のアルバムの曲 を再生
+
+GeeMusicPlaySimilarSongsRadioIntent 似てる曲を再生
+GeeMusicPlaySimilarSongsRadioIntent 似た曲を再生
+GeeMusicPlaySimilarSongsRadioIntent この曲のラジオを開始
+
+GeeMusicPlaySongIntent {song_name} の曲を再生
+GeeMusicPlaySongIntent {artist_name} の {song_name} の曲を再生
+GeeMusicPlaySongIntent {artist_name} の曲 {song_name} を再生
+GeeMusicPlaySongIntent {song_name} を再生
+GeeMusicPlaySongIntent {artist_name} の {song_name} を再生
+
+GeeMusicPlayArtistRadioIntent アーティスト {artist_name} のラジオを開始
+GeeMusicPlayArtistRadioIntent {artist_name} のアーティストのラジオを開始
+GeeMusicPlayArtistRadioIntent {artist_name} のアーティストのラジオステーションを作成
+GeeMusicPlayArtistRadioIntent {artist_name} のアーティストラジオを開始
+GeeMusicPlayArtistRadioIntent {artist_name} に似たアーティストを再生
+
+GeeMusicPlaySongRadioIntent {song_name} の曲のラジオを開始
+GeeMusicPlaySongRadioIntent {song_name} の曲のラジオステーションを作成
+GeeMusicPlaySongRadioIntent {song_name} に似た曲を再生
+GeeMusicPlaySongRadioIntent {artist_name} の {song_name} に似た曲を再生
+GeeMusicPlaySongRadioIntent {album_name} の {artist_name} の {song_name} に似た曲を再生
+
+GeeMusicPlayPlaylistIntent {playlist_name} のプレイリストを再生
+GeeMusicPlayPlaylistIntent プレイリスト {playlist_name}
+GeeMusicPlayPlaylistIntent プレイリスト {playlist_name} を再生
+GeeMusicPlayPlaylistIntent {playlist_name} のプレイリストを開始
+GeeMusicPlayPlaylistIntent {playlist_name} のプレイリストの曲を再生
+
+GeeMusicQueueSongIntent {song_name} の曲を次に再生
+GeeMusicQueueSongIntent {song_name} を次に再生
+GeeMusicQueueSongIntent {artist_name} の {song_name} を次に再生
+GeeMusicQueueSongIntent {artist_name} の曲 {song_name} を次に再生
+GeeMusicQueueSongIntent {artist_name} の {song_name} の曲を次に再生
+GeeMusicQueueSongIntent {song_name} をキューに追加
+GeeMusicQueueSongIntent {artist_name} の {song_name} をキューに追加
+
+GeeMusicListAllAlbumsIntent {artist_name} のアルバムを教えて
+
+GeeMusicListLatestAlbumIntent {artist_name} の最新のアルバムを教えて
+GeeMusicListLatestAlbumIntent {artist_name} の最新のアルバムは
+
+GeeMusicPlayLatestAlbumIntent {artist_name} の最新のアルバムを再生
+
+GeeMusicPlayAlbumByArtistIntent {artist_name} のバンドのアルバムを再生
+GeeMusicPlayAlbumByArtistIntent {artist_name} のアルバムを再生
+
+GeeMusicSkipTo {song_name} にスキップ
+GeeMusicSkipTo {artist_name} の {song_name} にスキップ
+
+GeeMusicPlayIFLRadioIntent 音楽をかけて
+GeeMusicPlayIFLRadioIntent 音楽を再生して
+GeeMusicPlayIFLRadioIntent 曲をかけて
+GeeMusicPlayIFLRadioIntent 曲を再生して
+GeeMusicPlayIFLRadioIntent アイムフィーリングラッキーを再生
+GeeMusicPlayIFLRadioIntent ラジオステーションを再生
+GeeMusicPlayIFLRadioIntent ラジオステーションを開始
+
+GeeMusicPlayLibraryIntent ライブラリーの曲を再生
+GeeMusicPlayLibraryIntent ライブラリーの楽曲を再生
+GeeMusicPlayLibraryIntent ライブラリーを再生
+
+GeeMusicCurrentlyPlayingIntent この曲は何
+GeeMusicCurrentlyPlayingIntent この曲について教えて
+GeeMusicCurrentlyPlayingIntent 今流れている曲は
+GeeMusicCurrentlyPlayingIntent 何が流れてる
+GeeMusicCurrentlyPlayingIntent この曲の名前は
+GeeMusicCurrentlyPlayingIntent これは何
+
+GeeMusicRestartTracksIntent もう一度再生
+GeeMusicRestartTracksIntent プレイリストをもう一度再生
+GeeMusicRestartTracksIntent 最初の曲まで戻って
+
+GeeMusicThumbsUpIntent お気に入りに追加
+GeeMusicThumbsUpIntent この曲を評価
+
+GeeMusicPlayThumbsUpIntent お気に入りの曲を再生
+GeeMusicPlayThumbsUpIntent お気に入りを再生
+GeeMusicPlayThumbsUpIntent 評価した曲を再生
+
+GeeMusicThumbsDownIntent この曲を低く評価
+GeeMusicThumbsDownIntent この曲は嫌い
+
+GeeMusicPlayDifferentAlbumIntent 違うアルバムを再生
+
+GeeMusicListAllPlaylists どんなプレイリストがある
+GeeMusicListAllPlaylists プレイリストを教えて
+GeeMusicListAllPlaylists プレイリストをリストアップ

--- a/speech_assets/sampleUtterances.ja.txt
+++ b/speech_assets/sampleUtterances.ja.txt
@@ -86,13 +86,17 @@ GeeMusicRestartTracksIntent プレイリストをもう一度再生
 GeeMusicRestartTracksIntent 最初の曲まで戻って
 
 GeeMusicThumbsUpIntent お気に入りに追加
-GeeMusicThumbsUpIntent この曲を評価
+GeeMusicThumbsUpIntent この曲を高評価
+GeeMusicThumbsUpIntent この曲を高く評価
 
 GeeMusicPlayThumbsUpIntent お気に入りの曲を再生
 GeeMusicPlayThumbsUpIntent お気に入りを再生
-GeeMusicPlayThumbsUpIntent 評価した曲を再生
+GeeMusicPlayThumbsUpIntent 高評価した曲を再生
+GeeMusicPlayThumbsUpIntent 高く評価した曲を再生
 
 GeeMusicThumbsDownIntent この曲を低く評価
+GeeMusicThumbsDownIntent この曲に低評価して
+GeeMusicThumbsDownIntent この曲を低評価
 GeeMusicThumbsDownIntent この曲は嫌い
 
 GeeMusicPlayDifferentAlbumIntent 違うアルバムを再生


### PR DESCRIPTION
I added only Japanese utterances.

This is related to #150 , but not resolving it completely. To provide full-support, Japanese responses and sample slot data should be added.

But it should be useful without them, because Japanese people can ask to Alexa in Japanese.