### PR TITLE
Fix wrong variable reference

### DIFF
--- a/geemusic/intents/playback.py
+++ b/geemusic/intents/playback.py
@@ -161,6 +161,7 @@ def list_all_playlists():
 
     all_playlists = api.get_all_user_playlist_contents()
     playlist_names = []
+    total_playlists = 0
     for i, match in enumerate(all_playlists):
 
         playlist_names.append(match['name'])


### PR DESCRIPTION
If there is no playlists in GPM account, `total_playlists` will never be assigned.

Here is my log of the error.

```
06:05:51 web.1  | Traceback (most recent call last):
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1997, in __call__
06:05:51 web.1  |     return self.wsgi_app(environ, start_response)
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1985, in wsgi_app
06:05:51 web.1  |     response = self.handle_exception(e)
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1540, in handle_exception
06:05:51 web.1  |     reraise(exc_type, exc_value, tb)
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
06:05:51 web.1  |     raise value
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
06:05:51 web.1  |     response = self.full_dispatch_request()
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
06:05:51 web.1  |     rv = self.handle_user_exception(e)
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
06:05:51 web.1  |     reraise(exc_type, exc_value, tb)
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
06:05:51 web.1  |     raise value
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
06:05:51 web.1  |     rv = self.dispatch_request()
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
06:05:51 web.1  |     return self.view_functions[rule.endpoint](**req.view_args)
06:05:51 web.1  |   File "/usr/lib/python3.6/site-packages/flask_ask/core.py", line 629, in _flask_view_func
06:05:51 web.1  |     result = self._map_intent_to_view_func(self.request.intent)()
06:05:51 web.1  |   File "/geemusic/geemusic/intents/playback.py", line 177, in list_all_playlists
06:05:51 web.1  |     speech_text = "You have %s playlists in your library. They are, %s." % (total_playlists, playlist_names)
06:03:41 web.1  | UnboundLocalError: local variable 'total_playlists' referenced before assignment
```