### PR TITLE
Use getenv instead of environ in __init__ to handle no supplied DEBUG env-var

### DIFF
--- a/geemusic/__init__.py
+++ b/geemusic/__init__.py
@@ -1,23 +1,22 @@
 from __future__ import absolute_import
 from flask import Flask
 from flask_ask import Ask
-from os import environ
+from os import getenv
 import logging
 
 from .utils.music import GMusicWrapper
 from .utils.music_queue import MusicQueue
 
-if 'LANGUAGE' in environ.keys():
-    language = environ['LANGUAGE']
-else:
-    language = "en"
-
+# Use English as default when no
+# LANGUAGE env is found.
+language = getenv('LANGUAGE', 'en')
+    
 TEMPLATE_DIR = "templates/" + language + ".yaml"
     
 app = Flask(__name__)
 ask = Ask(app, '/alexa', path=TEMPLATE_DIR)
 
-if str(environ['DEBUG_MODE']) is True:
+if str(getenv('DEBUG_MODE')) is True:
     log_level = logging.DEBUG
 else:
     log_level = logging.INFO


### PR DESCRIPTION
Fix issue shown in #187 

Issue is about DEBUG not existing, so we can FORCE people to use it, or just use this implementation.