### PR TITLE
Environment variables are strings.

### DIFF
--- a/geemusic/__init__.py
+++ b/geemusic/__init__.py
@@ -16,7 +16,7 @@ TEMPLATE_DIR = "templates/" + language + ".yaml"
 app = Flask(__name__)
 ask = Ask(app, '/alexa', path=TEMPLATE_DIR)
 
-if str(getenv('DEBUG_MODE')) is True:
+if getenv('DEBUG_MODE') == "True":
     log_level = logging.DEBUG
 else:
     log_level = logging.INFO


### PR DESCRIPTION
Removes the `str` cast on the `getenv` because environment variables are strings. Changed it to a string test instead of a Boolean test in the conditional.

This is because I tested it and these were my results:

```
#  "DEBUG_MODE"="True"
>>> str(getenv("DEBUG_MODE")) is True # returns False

# "DEBUG_MODE"="True"
>>> getenv("DEBUG_MODE") is True # returns False

# "DEBUG_MODE"="True"
>>>> getenv("DEBUG_MODE") == "True" # returns True
```