### PR TITLE
Fixed intent slots for non-US versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Repeat the process for each of the slots.
 
 The sample data was scraped from the UK top 100 singles and album chart. For the MUSICPLAYLISTS there are some generic sample phrases. The sample data is fine to use, don't feel you need to fill these slots to match your own collection.
 
-After you have added the "Custom Slots" you need to copy and paste the contents of `/speech_assets/non_us_custom_slot_version/intentSchema.json` to the intent schema field and the contents of `speech_assets/sampleUtterances.txt` to the sample utterances field. For Japanese users, use `speech_assets/sampleUtterances.ja.txt` to the utterances field.
+After you have added the "Custom Slots" you need to copy and paste the contents of `/speech_assets/non_us_custom_slot_version/intentSchema.json` to the intent schema field and the contents of `speech_assets/sampleUtterances.txt` to the sample utterances field. For other languages, use `speech_assets/sampleUtterances.<language>.txt`, e.g. `speech_assets/sampleUtterances.ja.txt` to the utterances field.
 
 
 ### Configuration
@@ -240,7 +240,7 @@ Finally, run the container with the appropriate environment variables and port f
 
 ```bash
 $ docker run -d -e GOOGLE_EMAIL=steve@stevegattuso.me -e GOOGLE_PASSWORD=[password] \
--e APP_URL=http://alexa-geemusic.stevegattuso.me -p 4000:4000 geemusic
+-e APP_URL=http://alexa-geemusic.stevegattuso.me -p 5000:5000 geemusic
 ```
 
 At this point you're set up and ready.

--- a/speech_assets/non_us_custom_slot_version/intentSchema.json
+++ b/speech_assets/non_us_custom_slot_version/intentSchema.json
@@ -1,50 +1,50 @@
 {
-	"intents": [
-		{
-			"intent": "AMAZON.PauseIntent"
-		},
-		{
-			"intent": "AMAZON.ResumeIntent"
-		},
-		{
-			"intent": "GeeMusicPlayArtistIntent",
-			"slots": [
-				{"name": "artist_name", "type": "MUSICGROUP"}
-			]
-		},
-		{
-			"intent": "GeeMusicPlayAlbumIntent",
-			"slots": [
-				{"name": "album_name", "type": "MUSICALBUM"},
-				{"name": "artist_name", "type": "MUSICGROUP"}
-			]
-		},
-		{
-			"intent": "GeeMusicPlaySongIntent",
-			"slots": [
-				{"name": "song_name", "type": "MUSICRECORDING"},
-				{"name": "artist_name", "type": "MUSICGROUP"}
-			]
-		},
-		{
-			"intent": "GeeMusicPlayArtistRadioIntent",
-			"slots": [
-				{"name": "artist_name", "type": "MUSICGROUP"}
-			]
-		},
-		{
-			"intent": "GeeMusicPlayPlaylistIntent",
-			"slots": [
-				{"name": "playlist_name", "type": "MUSICPLAYLIST"}
-			]
-		},
-		{
-			"intent": "GeeMusicQueueSongIntent",
-			"slots": [
-				{"name": "song_name", "type": "MUSICRECORDING"},
-				{"name": "artist_name", "type": "MUSICGROUP"}
-			]
-		},
+    "intents": [
+        {
+            "intent": "AMAZON.PauseIntent"
+        },
+        {
+            "intent": "AMAZON.ResumeIntent"
+        },
+        {
+            "intent": "GeeMusicPlayArtistIntent",
+            "slots": [
+                {"name": "artist_name", "type": "MUSICGROUP"}
+            ]
+        },
+        {
+            "intent": "GeeMusicPlayAlbumIntent",
+            "slots": [
+                {"name": "album_name", "type": "MUSICALBUM"},
+                {"name": "artist_name", "type": "MUSICGROUP"}
+            ]
+        },
+        {
+            "intent": "GeeMusicPlaySongIntent",
+            "slots": [
+                {"name": "song_name", "type": "MUSICRECORDING"},
+                {"name": "artist_name", "type": "MUSICGROUP"}
+            ]
+        },
+        {
+            "intent": "GeeMusicPlayArtistRadioIntent",
+            "slots": [
+                {"name": "artist_name", "type": "MUSICGROUP"}
+            ]
+        },
+        {
+            "intent": "GeeMusicPlayPlaylistIntent",
+            "slots": [
+                {"name": "playlist_name", "type": "MUSICPLAYLIST"}
+            ]
+        },
+        {
+            "intent": "GeeMusicQueueSongIntent",
+            "slots": [
+                {"name": "song_name", "type": "MUSICRECORDING"},
+                {"name": "artist_name", "type": "MUSICGROUP"}
+            ]
+        },
         {
             "intent":"GeeMusicListAllAlbumsIntent",
             "slots": [
@@ -69,13 +69,13 @@
                 {"name": "artist_name", "type": "MUSICGROUP"}
             ]
         },
-		{
-			"intent":"GeeMusicSkipTo",
-			"slots": [
-				{"name":"song_name", "type":"MUSICRECORDING"},
-				{"name":"artist_name", "type":"MUSICGROUP"}
-			]
-		},
+        {
+            "intent":"GeeMusicSkipTo",
+            "slots": [
+                {"name":"song_name", "type":"MUSICRECORDING"},
+                {"name":"artist_name", "type":"MUSICGROUP"}
+            ]
+        },
         {
             "intent": "GeeMusicPlayIFLRadioIntent"
         },
@@ -103,17 +103,17 @@
         {
             "intent": "GeeMusicPlaySongRadioIntent",
             "slots": [
-			    {"name":"song_name", "type":"MUSICRECORDING"},
+                {"name":"song_name", "type":"MUSICRECORDING"},
                 {"name": "album_name", "type": "MUSICALBUM"},
                 {"name":"artist_name", "type":"MUSICGROUP"}
-			]
+            ]
         },
         {
             "intent": "GeeMusicPlayThumbsUpIntent"
         },
         {
-	    "intent": "GeeMusicListAllPlaylists"
-	    },
+        "intent": "GeeMusicListAllPlaylists"
+        },
         {
             "intent": "AMAZON.ShuffleOnIntent"
         },
@@ -129,5 +129,5 @@
         {
             "intent": "AMAZON.HelpIntent"
         }
-	]
+    ]
 }

--- a/speech_assets/non_us_custom_slot_version/intentSchema.json
+++ b/speech_assets/non_us_custom_slot_version/intentSchema.json
@@ -97,9 +97,23 @@
         {
             "intent": "GeeMusicPlayDifferentAlbumIntent"
         },
-	{
+        {
+            "intent": "GeeMusicPlaySimilarSongsRadioIntent"
+        },
+        {
+            "intent": "GeeMusicPlaySongRadioIntent",
+            "slots": [
+			    {"name":"song_name", "type":"MUSICRECORDING"},
+                {"name": "album_name", "type": "MUSICALBUM"},
+                {"name":"artist_name", "type":"MUSICGROUP"}
+			]
+        },
+        {
+            "intent": "GeeMusicPlayThumbsUpIntent"
+        },
+        {
 	    "intent": "GeeMusicListAllPlaylists"
-	},
+	    },
         {
             "intent": "AMAZON.ShuffleOnIntent"
         },

--- a/speech_assets/sampleUtterances.de.txt
+++ b/speech_assets/sampleUtterances.de.txt
@@ -4,6 +4,12 @@ GeeMusicPlayArtistIntent Spiele top Songs von {artist_name}
 GeeMusicPlayArtistIntent Spiele Hits von {artist_name}
 GeeMusicPlayArtistIntent Spiele Musik von {artist_name}
 GeeMusicPlayArtistIntent Spiele {artist_name} ab
+GeeMusicPlayArtistIntent Spiele {artist_name} auf Gee Music
+GeeMusicPlayArtistIntent Spiele Lieder von {artist_name} auf Gee Music
+GeeMusicPlayArtistIntent Spiele top Songs von {artist_name} auf Gee Music
+GeeMusicPlayArtistIntent Spiele Hits von {artist_name} auf Gee Music
+GeeMusicPlayArtistIntent Spiele Musik von {artist_name} auf Gee Music
+GeeMusicPlayArtistIntent Spiele {artist_name} auf Gee Musicab
 
 GeeMusicPlayAlbumIntent Spiele das Album {album_name}
 GeeMusicPlayAlbumIntent Spiele Album {album_name}
@@ -11,7 +17,16 @@ GeeMusicPlayAlbumIntent Spiele das Album {album_name} von {artist_name}
 GeeMusicPlayAlbumIntent Spiele Album {album_name} von {artist_name}
 GeeMusicPlayAlbumIntent Spiele Lieder vom Album {album_name} von {artist_name}
 GeeMusicPlayAlbumIntent Spiele Lieder aus dem Album {album_name} von {artist_name}
+GeeMusicPlayAlbumIntent Spiele das Album {album_name} auf Gee Music
+GeeMusicPlayAlbumIntent Spiele Album {album_name} auf Gee Music
+GeeMusicPlayAlbumIntent Spiele das Album {album_name} von {artist_name} auf Gee Music
+GeeMusicPlayAlbumIntent Spiele Album {album_name} von {artist_name} auf Gee Music
+GeeMusicPlayAlbumIntent Spiele Lieder vom Album {album_name} von {artist_name} auf Gee Music
+GeeMusicPlayAlbumIntent Spiele Lieder aus dem Album {album_name} von {artist_name} auf Gee Music
 
+GeeMusicPlaySimilarSongsRadioIntent Spiele ähnliche Lieder auf Gee Music
+GeeMusicPlaySimilarSongsRadioIntent Spiele Lieder die so sind wie dieses auf Gee Music
+GeeMusicPlaySimilarSongsRadioIntent Starte ein Radio mit diesem Lied auf Gee Music
 GeeMusicPlaySimilarSongsRadioIntent Spiele ähnliche Lieder
 GeeMusicPlaySimilarSongsRadioIntent Spiele Lieder die so sind wie dieses
 GeeMusicPlaySimilarSongsRadioIntent Starte ein Radio mit diesem Lied


### PR DESCRIPTION
While creating a skill, i discovered (say: Amazon noticed me) that there are some SampleUtterances which aren't covered by the intentSchema.json. So i added them to the intentschema, and created this pull request. 
I don't know why github displays the json indents so messy, my VSCode displays them right. I hope its no problem. 