### PR TITLE
Fixed README and Dockerfile for the foreman default port being 5000 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /geemusic
 RUN pip3 install -r requirements.txt \
  && gem install foreman
 
-EXPOSE 4000
+EXPOSE 5000
 
 # Make sure to run with the GOOGLE_EMAIL, GOOGLE_PASSWORD, and APP_URL environment vars!
 ENTRYPOINT ["/usr/bin/dumb-init"]

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Once `foreman` is ready to go, simply run
 $ foreman start
 ```
 
-and you should see your web server start at http://localhost:4000 (although it won't do much if you visit it with your browser).
+and you should see your web server start at http://localhost:5000 (although it won't do much if you visit it with your browser).
 
 ## Create the development Skill on Amazon
 
@@ -240,7 +240,7 @@ Finally, run the container with the appropriate environment variables and port f
 
 ```bash
 $ docker run -d -e GOOGLE_EMAIL=steve@stevegattuso.me -e GOOGLE_PASSWORD=[password] \
--e APP_URL=http://alexa-geemusic.stevegattuso.me -p 4000:4000 geemusic
+-e APP_URL=http://alexa-geemusic.stevegattuso.me -p 5000:5000 geemusic
 ```
 
 At this point you're set up and ready.


### PR DESCRIPTION
Foreman's default port is now 5000. The Dockerfile should expose this port, as well as the README should respect this port use. 