### PR TITLE
Downgrade pip to support a bug in Flask-Ask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update \
 COPY . /geemusic
 WORKDIR /geemusic
 
-RUN pip3 install -r requirements.txt \
+RUN pip3 install -U 'pip<10' && pip3 install -r requirements.txt \
  && gem install foreman
 
 EXPOSE 5000


### PR DESCRIPTION
The latest released version of Flask-Ask has an issue when using pip >=
10. (https://github.com/johnwheeler/flask-ask/pull/231). As the docker
base image now includes a newer pip, we need to first downgrade pip
before starting the installation of flask-ask