### PR TITLE
Return empty response on playback status notifications

### DIFF
--- a/geemusic/intents/playback.py
+++ b/geemusic/intents/playback.py
@@ -9,16 +9,21 @@ import json
 #
 
 
+def empty_response():
+    return json.dumps({"response" : {}, "version" : "1.0" }), 200
+
 @ask.on_playback_stopped()
 def stopped(offset):
     queue.paused_offset = offset
     app.logger.debug(render_template("stopped", offset=offset))
+    return empty_response()
 
 
 @ask.on_playback_started()
 def started(offset):
     app.logger.debug(render_template("started", offset=offset))
 
+    return empty_response()
 
 @ask.on_playback_nearly_finished()
 def nearly_finished():
@@ -33,6 +38,7 @@ def nearly_finished():
 @ask.on_playback_finished()
 def finished():
     queue.next()
+    return empty_response()
 
 ##
 # Intents

--- a/geemusic/intents/playback.py
+++ b/geemusic/intents/playback.py
@@ -33,6 +33,7 @@ def nearly_finished():
         stream_url = api.get_stream_url(next_id)
 
         return audio().enqueue(stream_url)
+    return empty_response()
 
 
 @ask.on_playback_finished()


### PR DESCRIPTION
The documentation for Flask-Ask shows these events not having a return
code, which results in a 400, which causes Alexa to send back a failure
notification, which causes another 400.

Based on https://forums.developer.amazon.com/questions/93088/what-is-the-correct-way-to-return-nothing-for-audi.html,
this commit sends back a basically empty response, but still valid JSON.