### PR TITLE
Use a unique queue for each device

### DIFF
--- a/geemusic/utils/music_queue.py
+++ b/geemusic/utils/music_queue.py
@@ -1,8 +1,48 @@
 from builtins import object
+from flask_ask import context
 import random
 
-
 class MusicQueue(object):
+    def __init__(self, api, tracks=[]):
+        self.queues = {}
+        self.api = api
+
+    def get_or_create_queue(self, queue_id):
+        if not queue_id in self.queues:
+            self.queues[queue_id] = MusicQueueInternal(self.api)
+        return self.queues[queue_id]
+
+    def next(self):
+        return self.get_or_create_queue(context.System.device.deviceId).next()
+
+    def up_next(self):
+        return self.get_or_create_queue(context.System.device.deviceId).up_next()
+
+    def prev(self):
+        return self.get_or_create_queue(context.System.device.deviceId).prev()
+
+    def current(self):
+        return self.get_or_create_queue(context.System.device.deviceId).current()
+
+    def current_track(self):
+        return self.get_or_create_queue(context.System.device.deviceId).current_track()
+
+    def reset(self, tracks=[]):
+        return self.get_or_create_queue(context.System.device.deviceId).reset(tracks)
+
+    def enqueue_track(self, song):
+        return self.get_or_create_queue(context.System.device.deviceId).enqueue_track(song)
+
+    def shuffle_mode(self, value):
+        return self.get_or_create_queue(context.System.device.deviceId).shuffle_mode(value)
+
+    def loop_mode(self, value):
+        return self.get_or_create_queue(context.System.device.deviceId).loop_mode(value)
+
+    def __str__(self):
+        return self.get_or_create_queue(context.System.device.deviceId).__str__()
+
+class MusicQueueInternal(object):
     def __init__(self, api, tracks=[]):
         self.reset(tracks)
         self.current_index = 0

--- a/geemusic/utils/music_queue.py
+++ b/geemusic/utils/music_queue.py
@@ -7,6 +7,24 @@ class MusicQueue(object):
         self.queues = {}
         self.api = api
 
+    def __setattr__(self, name, value):
+        if name == 'queues' or name =='api':
+            super().__setattr__(name, value)
+        else:
+            return self.get_or_create_queue(context.System.device.deviceId).__setattr__(name, value)
+
+    def __hasattr__(self, name):
+        if name == 'queues' or name =='api':
+            return super().__hasattr__(name)
+        else:
+            return self.get_or_create_queue(context.System.device.deviceId).__hasattr__(name)
+
+    def __getattr__(self, name):
+        if name == 'queues' or name =='api':
+            return super().__getattr__(name)
+        else:
+            return self.get_or_create_queue(context.System.device.deviceId).__getattribute__(name)  # object methods don't have __getattr__
+
     def get_or_create_queue(self, queue_id):
         if not queue_id in self.queues:
             self.queues[queue_id] = MusicQueueInternal(self.api)


### PR DESCRIPTION
By default, all devices share the same queue on the side of the skill, but expect to get their own URL. This causes issues when playing back on multiple echo devices (not multi-room, just asking for music playback on two speakers). 

To keep the API simple, this is a drop in replacement for the existing queues, using Flask-Ask's `context` variable, which contains the device id of the requesting device. 