### PR TITLE
[Issue #276] Last.fm scrobbling improvement

### DIFF
--- a/geemusic/controllers.py
+++ b/geemusic/controllers.py
@@ -41,15 +41,6 @@ def index():
 @app.route("/alexa/stream/<song_id>")
 def redirect_to_stream(song_id):
     stream_url = api.get_google_stream_url(song_id)
-    # Scrobble if Last.fm is setup
-    if environ.get('LAST_FM_ACTIVE'):
-        from .utils import last_fm
-        song_info = api.get_song_data(song_id)
-        last_fm.scrobble(
-            song_info['title'],
-            song_info['artist'],
-            environ['LAST_FM_SESSION_KEY']
-        )
 
     app.logger.debug('URL is %s' % stream_url)
     req = requests.get(stream_url, stream=False)

--- a/geemusic/intents/playback.py
+++ b/geemusic/intents/playback.py
@@ -1,6 +1,7 @@
 from flask import render_template
 from flask_ask import statement, audio
 from geemusic import ask, queue, app, api
+from os import environ
 import json
 
 
@@ -40,6 +41,19 @@ def nearly_finished():
 
 @ask.on_playback_finished()
 def finished():
+    # Scrobble if Last.fm is setup
+    if environ.get('LAST_FM_ACTIVE'):
+        song_info = queue.current_track()
+
+        if song_info is not None and 'title' in song_info and 'artist' in song_info:
+            from ..utils import last_fm
+
+            last_fm.scrobble(
+                song_info['title'],
+                song_info['artist'],
+                environ['LAST_FM_SESSION_KEY']
+            )
+
     queue.next()
     return empty_response()
 


### PR DESCRIPTION
According to the issue https://github.com/stevenleeg/geemusic/issues/276: Last.fm scrobbling was not working properly. The problem was manifested on the following ways:
- the song would be scrobbled immediately after started playing -> false scrobbles when skipping songs
- it would scrobble the next queued song, instead of currently playing song
- it would generate up to 3 scrobbles for the same song, for some reason

I moved the scrobbling code to the `finished_playing` intent, which means that the song will get scrobbled once it finishes playing. This is still far from perfect, because most people love for the song the be scrobbled after it was played for more than 50%. On this way, the song won't be scrobbled if you, for example, skip the song or stop the playback, even though you might listened to 90% of the song. So it will be scrobbled only if you listen it till the end. But I think that this is far better then before, because there will be no more false scrobbles.

I've been testing this modification for the last week and it works fine. My last.fm list of scrobbled songs is now very clean and precise. No more false or duplicate scrobbles.

Later, when I found some time, I will try to improve this even more, to somehow check on skip/stop if the song has been played for at least X % (where X will be the environment variable) and then scrobble or even better - automatically scrobble the song when it reaches X %.