### PR TITLE
add links to json files in the Skill setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ See the note at the top about supported languages.
 
 #### US English users
 
-On the "Interaction Model" step, paste in the contents of `speech_assets/interactionModel.json` to the JSON Editor.
+On the "Interaction Model" step, paste in the contents of [`speech_assets/interactionModel.json`](https://raw.githubusercontent.com/stevenleeg/geemusic/master/speech_assets/interactionModel.json) to the JSON Editor.
 
 #### Other language users
 
-On the "Interaction Model" step, paste in the contents of `speech_assets/non_us_custom_slot_version/interactionModel.json` to the JSON Editor.
+On the "Interaction Model" step, paste in the contents of [`speech_assets/non_us_custom_slot_version/interactionModel.json`](https://raw.githubusercontent.com/stevenleeg/geemusic/master/speech_assets/non_us_custom_slot_version/interactionModel.json) to the JSON Editor.
 
 
 ### Configuration


### PR DESCRIPTION
Just to make life a little easier... edited the Readme to directly link to the mentioned `.json` files in the Skills setup section