### PR TITLE
Update MarkupSafe version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ Jinja2==2.9.6
 jmespath==0.9.3
 kappa==0.6.0
 lambda-packages==0.19.0
-MarkupSafe==1.0
+MarkupSafe==1.1
 MechanicalSoup==0.7.0
 mock==2.0.0
 mutagen==1.38


### PR DESCRIPTION
As a fix to something in 1.0 that threw this error: 

File "/tmp/pip-build-wng88gqh/MarkupSafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature'